### PR TITLE
#2: Remove current page number from initialSelection

### DIFF
--- a/view/frontend/web/js/multi-facet-navigation.js
+++ b/view/frontend/web/js/multi-facet-navigation.js
@@ -20,10 +20,16 @@ define(['jquery', 'uiComponent', 'underscore', 'matchMedia', 'domReady!'], funct
 
         constructInitialParams: function () {
             var splitUrl = window.location.href.split('?');
+            var explodedParams;
             self.pageUrl = splitUrl[0];
-            /* Remove current page parameter */
-            splitUrl[1] = splitUrl[1].replace(/(^|\&)p\=\d*(?=\&?)/,'').replace(/^\&/,'');
-            self.initialSelection = splitUrl[1] ? self.explodeParams(splitUrl[1]) : {};
+
+            if (splitUrl[1]) {
+                explodedParams = self.explodeParams(splitUrl[1]);
+                delete explodedParams.p; /* Do not include 'page' parameter in initial params */
+                self.initialSelection = explodedParams;
+            } else {
+                self.initialSelection = {};
+            }
         },
 
         explodeParams: function (str) {


### PR DESCRIPTION
Connects to #2 

The regex covers all possible scenarios, page number parameter could be

- at the beginning of the string, or
- surrounded by other parameters, or
- at the end of the string

It does not match other parameters ending with the letter 'p' like `&cap=23`. Additional replace is required to remove remaining ampersand at the start of the string in scenario 1 if the parameter is followed by another one.